### PR TITLE
Comentarios LFSR y pll_div.

### DIFF
--- a/div_frec_pll/div_frec_pll.vhd
+++ b/div_frec_pll/div_frec_pll.vhd
@@ -50,7 +50,7 @@ begin
 ------ Instanciacion del PLL -------------------------------
 div_pll_inst : div_pll PORT MAP (
 		areset	 => areset_sig,
-		inclk0	 => inclk0_sig,
+		inclk0	 => inclk0_sig, -- En el PLL el reset es activo en alto y en tu contador es activo en bajo. Cuando uno funciona, el otro no.
 		c0	 => c0_sig,
 		locked	 => locked_sig);
 

--- a/sel_cont_lfsr/sel_cont_lfsr.vhd
+++ b/sel_cont_lfsr/sel_cont_lfsr.vhd
@@ -76,7 +76,7 @@ begin
 ------ Proceso de seleccion de largo del ------------------
 ------ contador LFSR --------------------------------------
 	sel_proc: Process (rst, clk_div, sel)
-		variable ancho_lfsr: integer;
+		variable ancho_lfsr: integer; -- Se debe indicar el rango, por ejemplo: integer(32 downto 0) 
 	begin
 	--- El cambio entre un contador y otro se debe ---------
 	--- realizar un reset para inicializar todas las -------
@@ -86,18 +86,18 @@ begin
 			when "00" =>
 				ancho_lfsr := ancho_lfsr_a;
 				sal_lfsr_i(31 downto ancho_lfsr) <= (others => 'Z');
-				if(rst= '0') then 
-					sal_lfsr_i <= (0 => '1', others => 'Z');
-					sal_lfsr_i(ancho_lfsr-1 downto 1) <= (others => '0');
-				else
+				if(rst= '0') then 											-- Esto se repite en todo el proceso. 
+					sal_lfsr_i <= (0 => '1', others => 'Z');				-- Se podría optimizar.
+					sal_lfsr_i(ancho_lfsr-1 downto 1) <= (others => '0');	--	
+				else														--
 					sal_lfsr_i(ancho_lfsr-1 downto 0) <= serial_in & sal_lfsr_i(ancho_lfsr-1 downto 1); 
 				end if;
 			when "01" =>
 				ancho_lfsr := ancho_lfsr_b;
 				sal_lfsr_i(31 downto ancho_lfsr) <= (others => 'Z');
 				if(rst= '0') then 
-					sal_lfsr_i <= (0 => '1', others => 'Z');
-					sal_lfsr_i(ancho_lfsr-1 downto 1) <= (others => '0');
+					sal_lfsr_i <= (0 => '1', others => 'Z');				-- Las señales 'Z' rara vez se usan. Solo en buses de comunicación. Además tus decoficadores BCD a 7 segmentos no lo usa. 
+					sal_lfsr_i(ancho_lfsr-1 downto 1) <= (others => '0');	
 				else
 					sal_lfsr_i(ancho_lfsr-1 downto 0) <= serial_in & sal_lfsr_i(ancho_lfsr-1 downto 1); 
 				end if;
@@ -121,6 +121,8 @@ begin
 		end case;
 		end if;
 	end process sel_proc;
+			-- Cambiaría la señal sal_lfsr_i por una auxiliar en el proceso y haría la siguiente asignación: sal_lfsr_i <= sal_lfsr_i.
+			-- Para evitar que se cree un latch, ya que no están contempladas todas las posibilidades del if en el proceso.
 	
 ---- Asignacion del valor de salida ---------------------
 	--sal_lfsr <= sal_lfsr_i;


### PR DESCRIPTION
Hola Leonardo,

Te hago comentarios de los siguientes componentes:

1- pll-div:

El reset del PLL y el contador los has conectado entre si. Esto no es problema, pero según tu código uno es activo en bajo y el otro en alto. Lo puse en los comentarios del código.

2- En el contador LFSR he realizado algunos comentarios para mejorar el código. No obstante no estoy seguro de cual es el error.  Según pude ver cuando lo probé en la placa serían los siguientes:

a) Cuando la selección está en cualquier combinación que no es la de 32, los displays que no se utilizan deberían estar apagados o todos los segmentos encendidos. En lugar de ello hay un 0.

b) Cuando la selección es "00" solamente un solo display debería cambiar, ya que es un contador LFSR de 4bits. En lugar de ello cambian 4 displays. 


